### PR TITLE
Fix order search parameter

### DIFF
--- a/src/main/java/com/playmatsec/app/repository/OrderRepository.java
+++ b/src/main/java/com/playmatsec/app/repository/OrderRepository.java
@@ -38,7 +38,7 @@ public class OrderRepository {
     public List<Order> search(String userId, Date createdAt, Date updatedAt, String status) {
         OrderSearchCriteria spec = new OrderSearchCriteria();
         if (StringUtils.isNotBlank(userId)) {
-            spec.add(new SearchStatement(OrderConsts.ID, userId, SearchOperation.EQUAL));
+            spec.add(new SearchStatement(OrderConsts.USER, userId, SearchOperation.EQUAL));
         }
         if (createdAt != null) {
             spec.add(new SearchStatement(OrderConsts.CREATED_AT, createdAt, SearchOperation.EQUAL));


### PR DESCRIPTION
## Summary
- correct constant when filtering orders by user

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_683f60a6683083269d8ac6fe72fa020b