### PR TITLE
Fix typo in Attribute JPA repository

### DIFF
--- a/src/main/java/com/playmatsec/app/repository/AttributeJpaRepository.java
+++ b/src/main/java/com/playmatsec/app/repository/AttributeJpaRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import com.playmatsec.app.repository.model.Attribute;
 
-public interface AttributeJpaRespository extends JpaRepository<Attribute, Long>, JpaSpecificationExecutor<Attribute> {
+public interface AttributeJpaRepository extends JpaRepository<Attribute, Long>, JpaSpecificationExecutor<Attribute> {
 
     // Custom query methods can be defined here if needed
     // For example:

--- a/src/main/java/com/playmatsec/app/repository/AttributeRepository.java
+++ b/src/main/java/com/playmatsec/app/repository/AttributeRepository.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Repository
 @RequiredArgsConstructor
 public class AttributeRepository {
-  private final AttributeJpaRespository repository;
+  private final AttributeJpaRepository repository;
 
   public List<Attribute> getAttributes() {
     return repository.findAll();


### PR DESCRIPTION
## Summary
- rename `AttributeJpaRespository` to `AttributeJpaRepository`
- update `AttributeRepository` to use the new interface name

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_683f6ba262a883268ef30fd30d49138a